### PR TITLE
Adding support for getAllOf() operation

### DIFF
--- a/dapr-spring-core/src/main/java/io/diagrid/spring/core/keyvalue/DaprKeyValueTemplate.java
+++ b/dapr-spring-core/src/main/java/io/diagrid/spring/core/keyvalue/DaprKeyValueTemplate.java
@@ -4,171 +4,344 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.dao.DataAccessException;
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.support.PersistenceExceptionTranslator;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.keyvalue.core.IdentifierGenerator;
 import org.springframework.data.keyvalue.core.KeyValueAdapter;
 import org.springframework.data.keyvalue.core.KeyValueCallback;
+import org.springframework.data.keyvalue.core.KeyValueOperations;
 import org.springframework.data.keyvalue.core.KeyValuePersistenceExceptionTranslator;
+import org.springframework.data.keyvalue.core.event.KeyValueEvent;
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentEntity;
 import org.springframework.data.keyvalue.core.mapping.KeyValuePersistentProperty;
 import org.springframework.data.keyvalue.core.mapping.context.KeyValueMappingContext;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
+import org.springframework.util.CollectionUtils;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
-public class DaprKeyValueTemplate implements DaprKeyValueOperations, ApplicationEventPublisherAware {
+public class DaprKeyValueTemplate implements KeyValueOperations, ApplicationEventPublisherAware {
 
     private static final PersistenceExceptionTranslator DEFAULT_PERSISTENCE_EXCEPTION_TRANSLATOR = new KeyValuePersistenceExceptionTranslator();
-    private final IdentifierGenerator identifierGenerator;
-    private final MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext;
+
     private final KeyValueAdapter adapter;
-    private final PersistenceExceptionTranslator exceptionTranslator = DEFAULT_PERSISTENCE_EXCEPTION_TRANSLATOR;
+    private final MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext;
+    private final IdentifierGenerator identifierGenerator;
 
+    private PersistenceExceptionTranslator exceptionTranslator = DEFAULT_PERSISTENCE_EXCEPTION_TRANSLATOR;
+    private @Nullable ApplicationEventPublisher eventPublisher;
+    private boolean publishEvents = false;
+    private @SuppressWarnings("rawtypes") Set<Class<? extends KeyValueEvent>> eventTypesToPublish = Collections
+            .emptySet();
+
+    /**
+     * Create new {@link DaprKeyValueTemplate} using the given {@link KeyValueAdapter} with a default
+     * {@link KeyValueMappingContext}.
+     *
+     * @param adapter must not be {@literal null}.
+     */
     public DaprKeyValueTemplate(KeyValueAdapter adapter) {
-        this(adapter, new KeyValueMappingContext<>(), DefaultIdentifierGenerator.INSTANCE);
-
+        this(adapter, new KeyValueMappingContext<>());
     }
 
-    public DaprKeyValueTemplate(KeyValueAdapter adapter, MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext, IdentifierGenerator identifierGenerator) {
+    /**
+     * Create new {@link DaprKeyValueTemplate} using the given {@link KeyValueAdapter} and {@link MappingContext}.
+     *
+     * @param adapter must not be {@literal null}.
+     * @param mappingContext must not be {@literal null}.
+     */
+    public DaprKeyValueTemplate(KeyValueAdapter adapter,
+                            MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext) {
+        this(adapter, mappingContext, DefaultIdentifierGenerator.INSTANCE);
+    }
+
+    /**
+     * Create new {@link DaprKeyValueTemplate} using the given {@link KeyValueAdapter} and {@link MappingContext}.
+     *
+     * @param adapter must not be {@literal null}.
+     * @param mappingContext must not be {@literal null}.
+     * @param identifierGenerator must not be {@literal null}.
+     */
+    public DaprKeyValueTemplate(KeyValueAdapter adapter,
+                            MappingContext<? extends KeyValuePersistentEntity<?, ?>, ? extends KeyValuePersistentProperty<?>> mappingContext,
+                            IdentifierGenerator identifierGenerator) {
+        Assert.notNull(adapter, "Adapter must not be null");
+        Assert.notNull(mappingContext, "MappingContext must not be null");
+        Assert.notNull(identifierGenerator, "IdentifierGenerator must not be null");
+
         this.adapter = adapter;
         this.mappingContext = mappingContext;
         this.identifierGenerator = identifierGenerator;
     }
 
-    @Override
-    public void destroy() throws Exception {
-        // TODO Auto-generated method stub
+    /**
+     * Set the {@link PersistenceExceptionTranslator} used for converting {@link RuntimeException}.
+     *
+     * @param exceptionTranslator must not be {@literal null}.
+     */
+    public void setExceptionTranslator(PersistenceExceptionTranslator exceptionTranslator) {
+        Assert.notNull(exceptionTranslator, "ExceptionTranslator must not be null");
+        this.exceptionTranslator = exceptionTranslator;
+    }
+
+    /**
+     * Define the event types to publish via {@link ApplicationEventPublisher}.
+     *
+     * @param eventTypesToPublish use {@literal null} or {@link Collections#emptySet()} to stop publishing.
+     */
+    @SuppressWarnings("rawtypes")
+    public void setEventTypesToPublish(Set<Class<? extends KeyValueEvent>> eventTypesToPublish) {
+        if (CollectionUtils.isEmpty(eventTypesToPublish)) {
+            this.publishEvents = false;
+        } else {
+            this.publishEvents = true;
+            this.eventTypesToPublish = Collections.unmodifiableSet(eventTypesToPublish);
+        }
     }
 
     @Override
     public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
-        // TODO Auto-generated method stub
+        this.eventPublisher = applicationEventPublisher;
     }
 
     @Override
     public <T> T insert(T objectToInsert) {
         KeyValuePersistentEntity<?, ?> entity = getKeyValuePersistentEntity(objectToInsert);
+        GeneratingIdAccessor generatingIdAccessor = new GeneratingIdAccessor(
+                entity.getPropertyAccessor(objectToInsert),
+                entity.getIdProperty(),
+                identifierGenerator
+        );
+        Object id = generatingIdAccessor.getOrGenerateIdentifier();
 
-		GeneratingIdAccessor generatingIdAccessor = new GeneratingIdAccessor(entity.getPropertyAccessor(objectToInsert),
-				entity.getIdProperty(), identifierGenerator);
-		Object id = generatingIdAccessor.getOrGenerateIdentifier();
-
-		return insert(id, objectToInsert);
+        return insert(id, objectToInsert);
     }
-
-    private KeyValuePersistentEntity<?, ?> getKeyValuePersistentEntity(Object objectToInsert) {
-		return this.mappingContext.getRequiredPersistentEntity(ClassUtils.getUserClass(objectToInsert));
-	}
-
-    private String resolveKeySpace(Class<?> type) {
-		return this.mappingContext.getRequiredPersistentEntity(type).getKeySpace();
-	}
 
     @Override
     public <T> T insert(Object id, T objectToInsert) {
         Assert.notNull(id, "Id for object to be inserted must not be null");
-		Assert.notNull(objectToInsert, "Object to be inserted must not be null");
+        Assert.notNull(objectToInsert, "Object to be inserted must not be null");
 
-		String keyspace = resolveKeySpace(objectToInsert.getClass());
+        String keyspace = resolveKeySpace(objectToInsert.getClass());
 
-		//potentiallyPublishEvent(KeyValueEvent.beforeInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
+        potentiallyPublishEvent(KeyValueEvent.beforeInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
 
-		execute((KeyValueCallback<Void>) adapter -> {
+        execute((KeyValueCallback<Void>) adapter -> {
 
-			if (adapter.contains(id, keyspace)) {
-				throw new DuplicateKeyException(
-						String.format("Cannot insert existing object with id %s; Please use update", id));
-			}
+            if (adapter.contains(id, keyspace)) {
+                throw new DuplicateKeyException(
+                        String.format("Cannot insert existing object with id %s; Please use update", id));
+            }
 
-			adapter.put(id, objectToInsert, keyspace);
-			return null;
-		});
+            adapter.put(id, objectToInsert, keyspace);
+            return null;
+        });
 
-		//potentiallyPublishEvent(KeyValueEvent.afterInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
+        potentiallyPublishEvent(KeyValueEvent.afterInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
 
-		return objectToInsert;
-    }
-
-    @Override
-    public <T> Iterable<T> findAll(Class<T> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findAll'");
-    }
-
-    @Override
-    public <T> Iterable<T> findInRange(long offset, int rows, Class<T> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'findInRange'");
+        return objectToInsert;
     }
 
     @Override
     public <T> T update(T objectToUpdate) {
         KeyValuePersistentEntity<?, ?> entity = getKeyValuePersistentEntity(objectToUpdate);
 
-		GeneratingIdAccessor generatingIdAccessor = new GeneratingIdAccessor(entity.getPropertyAccessor(objectToUpdate),
-				entity.getIdProperty(), identifierGenerator);
-		Object id = generatingIdAccessor.getOrGenerateIdentifier();
+        if (!entity.hasIdProperty()) {
+            throw new InvalidDataAccessApiUsageException(
+                    String.format("Cannot determine id for type %s", ClassUtils.getUserClass(objectToUpdate)));
+        }
 
-		return update(id, objectToUpdate);
+        return update(entity.getIdentifierAccessor(objectToUpdate).getRequiredIdentifier(), objectToUpdate);
     }
 
     @Override
     public <T> T update(Object id, T objectToUpdate) {
         Assert.notNull(id, "Id for object to be inserted must not be null");
-		Assert.notNull(objectToUpdate, "Object to be inserted must not be null");
+        Assert.notNull(objectToUpdate, "Object to be updated must not be null");
 
-		String keyspace = resolveKeySpace(objectToUpdate.getClass());
+        String keyspace = resolveKeySpace(objectToUpdate.getClass());
 
-		//potentiallyPublishEvent(KeyValueEvent.beforeInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
+        potentiallyPublishEvent(KeyValueEvent.beforeUpdate(id, keyspace, objectToUpdate.getClass(), objectToUpdate));
 
-		execute((KeyValueCallback<Void>) adapter -> {
-			adapter.put(id, objectToUpdate, keyspace);
-			return null;
-		});
+        Object existing = execute(adapter -> adapter.put(id, objectToUpdate, keyspace));
 
-		//potentiallyPublishEvent(KeyValueEvent.afterInsert(id, keyspace, objectToInsert.getClass(), objectToInsert));
+        potentiallyPublishEvent(
+                KeyValueEvent.afterUpdate(id, keyspace, objectToUpdate.getClass(), objectToUpdate, existing));
 
-		return objectToUpdate;
+        return objectToUpdate;
+    }
+
+    @Override
+    public <T> Iterable<T> findAll(Class<T> type) {
+        Assert.notNull(type, "Type to fetch must not be null");
+
+        return executeRequired(adapter -> {
+            Iterable<?> values = adapter.getAllOf(resolveKeySpace(type), type);
+
+            ArrayList<T> filtered = new ArrayList<>();
+            for (Object candidate : values) {
+                if (typeCheck(type, candidate)) {
+                    filtered.add(type.cast(candidate));
+                }
+            }
+
+            return filtered;
+        });
+    }
+
+    @Override
+    public <T> Optional<T> findById(Object id, Class<T> type) {
+        Assert.notNull(id, "Id for object to be found must not be null");
+        Assert.notNull(type, "Type to fetch must not be null");
+
+        String keyspace = resolveKeySpace(type);
+
+        potentiallyPublishEvent(KeyValueEvent.beforeGet(id, keyspace, type));
+
+        T result = execute(adapter -> {
+            Object value = adapter.get(id, keyspace, type);
+
+            if (value == null || typeCheck(type, value)) {
+                return type.cast(value);
+            }
+
+            return null;
+        });
+
+        potentiallyPublishEvent(KeyValueEvent.afterGet(id, keyspace, type, result));
+
+        return Optional.ofNullable(result);
     }
 
     @Override
     public void delete(Class<?> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+        Assert.notNull(type, "Type to delete must not be null");
+
+        String keyspace = resolveKeySpace(type);
+
+        potentiallyPublishEvent(KeyValueEvent.beforeDropKeySpace(keyspace, type));
+
+        execute((KeyValueCallback<Void>) adapter -> {
+
+            adapter.deleteAllOf(keyspace);
+            return null;
+        });
+
+        potentiallyPublishEvent(KeyValueEvent.afterDropKeySpace(keyspace, type));
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T> T delete(T objectToDelete) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+        Class<T> type = (Class<T>) ClassUtils.getUserClass(objectToDelete);
+        KeyValuePersistentEntity<?, ?> entity = getKeyValuePersistentEntity(objectToDelete);
+
+        return delete(entity.getIdentifierAccessor(objectToDelete).getIdentifier(), type);
     }
 
     @Override
     public <T> T delete(Object id, Class<T> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'delete'");
+        Assert.notNull(id, "Id for object to be deleted must not be null");
+        Assert.notNull(type, "Type to delete must not be null");
+
+        String keyspace = resolveKeySpace(type);
+
+        potentiallyPublishEvent(KeyValueEvent.beforeDelete(id, keyspace, type));
+
+        T result = execute(adapter -> adapter.delete(id, keyspace, type));
+
+        potentiallyPublishEvent(KeyValueEvent.afterDelete(id, keyspace, type, result));
+
+        return result;
     }
 
     @Override
     public long count(Class<?> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'count'");
+        Assert.notNull(type, "Type for count must not be null");
+        return adapter.count(resolveKeySpace(type));
+    }
+
+    @Nullable
+    @Override
+    public <T> T execute(KeyValueCallback<T> action) {
+        Assert.notNull(action, "KeyValueCallback must not be null");
+
+        try {
+            return action.doInKeyValue(this.adapter);
+        } catch (RuntimeException e) {
+            throw resolveExceptionIfPossible(e);
+        }
+    }
+
+    /**
+     * Execute {@link KeyValueCallback} and require a non-{@literal null} return value.
+     *
+     * @param action
+     * @param <T>
+     * @return
+     */
+    protected <T> T executeRequired(KeyValueCallback<T> action) {
+        T result = execute(action);
+
+        if (result != null) {
+            return result;
+        }
+
+        throw new IllegalStateException(String.format("KeyValueCallback %s returned null value", action));
+    }
+
+    @Override
+    public <T> Iterable<T> find(KeyValueQuery<?> query, Class<T> type) {
+        return executeRequired((KeyValueCallback<Iterable<T>>) adapter -> {
+            Iterable<?> result = adapter.find(query, resolveKeySpace(type), type);
+
+            List<T> filtered = new ArrayList<>();
+
+            for (Object candidate : result) {
+                if (typeCheck(type, candidate)) {
+                    filtered.add(type.cast(candidate));
+                }
+            }
+
+            return filtered;
+        });
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public <T> Iterable<T> findAll(Sort sort, Class<T> type) {
+        return find(new KeyValueQuery(sort), type);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public <T> Iterable<T> findInRange(long offset, int rows, Class<T> type) {
+        return find(new KeyValueQuery().skip(offset).limit(rows), type);
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Override
+    public <T> Iterable<T> findInRange(long offset, int rows, Sort sort, Class<T> type) {
+        return find(new KeyValueQuery(sort).skip(offset).limit(rows), type);
     }
 
     @Override
     public long count(KeyValueQuery<?> query, Class<?> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'count'");
+        return executeRequired(adapter -> adapter.count(query, resolveKeySpace(type)));
     }
 
     @Override
     public boolean exists(KeyValueQuery<?> query, Class<?> type) {
-        // TODO Auto-generated method stub
-        throw new UnsupportedOperationException("Unimplemented method 'exists'");
+        return executeRequired(adapter -> adapter.exists(query, resolveKeySpace(type)));
     }
 
     @Override
@@ -182,43 +355,36 @@ public class DaprKeyValueTemplate implements DaprKeyValueOperations, Application
     }
 
     @Override
-    public <T> T execute(KeyValueCallback<T> action) {
-        Assert.notNull(action, "KeyValueCallback must not be null");
+    public void destroy() throws Exception {
+        this.adapter.destroy();
+    }
 
-		try {
-			return action.doInKeyValue(this.adapter);
-		} catch (RuntimeException e) {
-			throw resolveExceptionIfPossible(e);
-		}
+    private KeyValuePersistentEntity<?, ?> getKeyValuePersistentEntity(Object objectToInsert) {
+        return this.mappingContext.getRequiredPersistentEntity(ClassUtils.getUserClass(objectToInsert));
+    }
+
+    private String resolveKeySpace(Class<?> type) {
+        return this.mappingContext.getRequiredPersistentEntity(type).getKeySpace();
     }
 
     private RuntimeException resolveExceptionIfPossible(RuntimeException e) {
-		DataAccessException translatedException = exceptionTranslator.translateExceptionIfPossible(e);
-		return translatedException != null ? translatedException : e;
-	}
 
-    @Override
-    public <T> Iterable<T> find(KeyValueQuery<?> query, Class<T> type) {
-        String keyspace = resolveKeySpace(type);
-        return adapter.find(query, keyspace, type);
+        DataAccessException translatedException = exceptionTranslator.translateExceptionIfPossible(e);
+        return translatedException != null ? translatedException : e;
     }
 
-    @Override
-    public <T> Iterable<T> findAll(Sort sort, Class<T> type) {
-        // TODO Auto-generated method stub
-        return null;
+    @SuppressWarnings("rawtypes")
+    private void potentiallyPublishEvent(KeyValueEvent event) {
+        if (eventPublisher == null) {
+            return;
+        }
+
+        if (publishEvents && (eventTypesToPublish.isEmpty() || eventTypesToPublish.contains(event.getClass()))) {
+            eventPublisher.publishEvent(event);
+        }
     }
 
-    @Override
-    public <T> Optional<T> findById(Object id, Class<T> type) {
-        String keyspace = resolveKeySpace(type);
-        return Optional.of(adapter.get(id, keyspace, type));
+    private static boolean typeCheck(Class<?> requiredType, @Nullable Object candidate) {
+        return candidate == null || ClassUtils.isAssignable(requiredType, candidate.getClass());
     }
-
-    @Override
-    public <T> Iterable<T> findInRange(long offset, int rows, Sort sort, Class<T> type) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
 }

--- a/dapr-spring-core/src/test/java/io/diagrid/spring/core/kvstore/DaprKeyValueTemplateIT.java
+++ b/dapr-spring-core/src/test/java/io/diagrid/spring/core/kvstore/DaprKeyValueTemplateIT.java
@@ -5,9 +5,9 @@ import io.dapr.client.DaprClient;
 import io.dapr.client.DaprClientBuilder;
 import io.diagrid.BaseIntegrationTest;
 import io.diagrid.spring.core.keyvalue.DaprKeyValueAdapter;
+import io.diagrid.spring.core.keyvalue.DaprKeyValueTemplate;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.springframework.data.keyvalue.core.KeyValueTemplate;
 import org.springframework.data.keyvalue.core.query.KeyValueQuery;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +29,7 @@ public class DaprKeyValueTemplateIT extends BaseIntegrationTest {
             "kvstore",
             "kvbinding"
     );
-    private final KeyValueTemplate keyValueTemplate = new KeyValueTemplate(daprKeyValueAdapter);
+    private final DaprKeyValueTemplate keyValueTemplate = new DaprKeyValueTemplate(daprKeyValueAdapter);
 
     @AfterEach
     public void tearDown() {
@@ -114,6 +114,17 @@ public class DaprKeyValueTemplateIT extends BaseIntegrationTest {
         var result = keyValueTemplate.findById(itemId, TestType.class);
 
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testGetAllOfDaprKeyValueTemplate() {
+        var itemId = 1;
+        var insertedType = keyValueTemplate.insert(new TestType(itemId, "test"));
+        assertThat(insertedType).isNotNull();
+
+        Iterable<TestType> result = keyValueTemplate.findAll(TestType.class);
+
+        assertThat(result.iterator().hasNext()).isTrue();
     }
 
 }


### PR DESCRIPTION
Here are the highlights of the PR:
- I have tried to synchronize `DaprKeyValueTemplate` with `KeyValueTemplate` so it is easier to follow what is exactly missing
- I have added support for `findAll()/getAllOf()`
- I have left `entries()` unimplemented, it is very specific to key/value and map concept